### PR TITLE
Update echo_server.lua

### DIFF
--- a/example/echo_server.lua
+++ b/example/echo_server.lua
@@ -7,7 +7,7 @@ local yaml = require('yaml')
 -- INITIALIZATION
 local function script_path()
     local str = debug.getinfo(2, "S").source:sub(2)
-    return str:match("(.*/)")
+    return str:match("(.*/)") or "."
 end
 local ctx = sslsocket.ctx(sslsocket.methods.tlsv1)
 local rc = sslsocket.ctx_use_private_key_file(ctx, script_path() .. 'certificate.pem')


### PR DESCRIPTION
Minor edit that if `str:match("(.*/)")` returns `nil` then the current directory will be returned at least. If this is not done, then an error will occur when connecting to another string.