### PR TITLE
Fix echo_server example (by dropping a log print)

### DIFF
--- a/example/echo_server.lua
+++ b/example/echo_server.lua
@@ -26,7 +26,6 @@ sslsocket.tcp_server(
     '0.0.0.0', 8443,
     function(client, from)
         log.info('client accepted %s', yaml.encode(from))
-        log.info('getaddrinfo: %s', yaml.encode(client:getaddrinfo()))
         local buf, err = client:read(10)
         if buf == nil then
             log.info('client error %s', err)


### PR DESCRIPTION
A socket object has no `getaddrinfo()` method. It seems, it was placed
here by a mistake.

The problem was reported in #1.